### PR TITLE
fix(marshaller): serialize attribute values outside expression builder

### DIFF
--- a/.changeset/forty-ravens-sniff.md
+++ b/.changeset/forty-ravens-sniff.md
@@ -1,0 +1,5 @@
+---
+'@driimus/dynamodb-data-marshaller': minor
+---
+
+fix: marhsall attribute values after serializing expression

--- a/packages/dynamodb-data-mapper/src/DataMapper.spec.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.spec.ts
@@ -1500,7 +1500,7 @@ describe('DataMapper', () => {
       expect(mockDynamoDbClient.commandCalls(DeleteItemCommand)[0].args[0].input).toMatchObject({
         ConditionExpression: '#attr0 = :val1',
         ExpressionAttributeNames: { '#attr0': 'pop' },
-        ExpressionAttributeValues: { ':val1': 21 },
+        ExpressionAttributeValues: { ':val1': { N: '21' } },
       });
     });
 
@@ -1614,8 +1614,8 @@ describe('DataMapper', () => {
           '#attr2': 'pop',
         },
         ExpressionAttributeValues: {
-          ':val1': 600_000,
-          ':val3': 21,
+          ':val1': { N: '600000' },
+          ':val3': { N: '21' },
         },
       });
     });
@@ -2863,7 +2863,7 @@ describe('DataMapper', () => {
         },
         ConditionExpression: '#attr0 = :val1',
         ExpressionAttributeNames: { '#attr0': 'pop' },
-        ExpressionAttributeValues: { ':val1': 21 },
+        ExpressionAttributeValues: { ':val1': { N: '21' } },
       });
     });
 
@@ -2983,8 +2983,8 @@ describe('DataMapper', () => {
           '#attr2': 'pop',
         },
         ExpressionAttributeValues: {
-          ':val1': 600_000,
-          ':val3': 21,
+          ':val1': { N: '600000' },
+          ':val3': { N: '21' },
         },
       });
     });
@@ -3268,8 +3268,8 @@ describe('DataMapper', () => {
           '#attr2': 'fizz',
         },
         ExpressionAttributeValues: {
-          ':val1': 'crackle',
-          ':val3': 'buz',
+          ':val1': { S: 'crackle' },
+          ':val3': { S: 'buz' },
         },
       });
     });
@@ -3289,9 +3289,9 @@ describe('DataMapper', () => {
           '#attr2': 'pop',
         },
         ExpressionAttributeValues: {
-          ':val1': 'crackle',
-          ':val3': 10,
-          ':val4': 20,
+          ':val1': { S: 'crackle' },
+          ':val3': { N: '10' },
+          ':val4': { N: '20' },
         },
       });
     });
@@ -3317,9 +3317,9 @@ describe('DataMapper', () => {
           '#attr2': 'fizzes',
         },
         ExpressionAttributeValues: {
-          ':val1': 'crackle',
-          ':val3': 'buzz',
-          ':val4': 'pop',
+          ':val1': { S: 'crackle' },
+          ':val3': { S: 'buzz' },
+          ':val4': { S: 'pop' },
         },
       });
     });
@@ -3340,7 +3340,7 @@ describe('DataMapper', () => {
           '#attr2': 'fizzes',
         },
         ExpressionAttributeValues: {
-          ':val1': 'crackle',
+          ':val1': { S: 'crackle' },
         },
       });
     });
@@ -3470,7 +3470,7 @@ describe('DataMapper', () => {
             KeyConditionExpression: '#attr0 = :val1',
             ExpressionAttributeNames: { '#attr0': 'snap' },
             ExpressionAttributeValues: {
-              ':val1': 'crackle',
+              ':val1': { S: 'crackle' },
             },
           },
         ],
@@ -3481,7 +3481,7 @@ describe('DataMapper', () => {
             KeyConditionExpression: '#attr0 = :val1',
             ExpressionAttributeNames: { '#attr0': 'snap' },
             ExpressionAttributeValues: {
-              ':val1': 'crackle',
+              ':val1': { S: 'crackle' },
             },
             ExclusiveStartKey: {
               snap: { S: 'pop' },
@@ -3495,7 +3495,7 @@ describe('DataMapper', () => {
             KeyConditionExpression: '#attr0 = :val1',
             ExpressionAttributeNames: { '#attr0': 'snap' },
             ExpressionAttributeValues: {
-              ':val1': 'crackle',
+              ':val1': { S: 'crackle' },
             },
             ExclusiveStartKey: {
               snap: { S: 'fizz' },
@@ -3753,7 +3753,7 @@ describe('DataMapper', () => {
           '#attr0': 'fizzes',
         },
         ExpressionAttributeValues: {
-          ':val1': 'buzz',
+          ':val1': { S: 'buzz' },
         },
       });
     });
@@ -4080,14 +4080,12 @@ describe('DataMapper', () => {
           },
           ExpressionAttributeValues: {
             ':val1': {
-              marshalled: {
-                L: [
-                  { N: '1' },
-                  {
-                    B: Uint8Array.from([0xde, 0xad, 0xbe, 0xef]),
-                  },
-                ],
-              },
+              L: [
+                { N: '1' },
+                {
+                  B: Uint8Array.from([0xde, 0xad, 0xbe, 0xef]),
+                },
+              ],
             },
           },
           UpdateExpression: 'SET #attr0 = :val1 REMOVE #attr2',
@@ -4110,14 +4108,12 @@ describe('DataMapper', () => {
           },
           ExpressionAttributeValues: {
             ':val1': {
-              marshalled: {
-                L: [
-                  { N: '1' },
-                  {
-                    B: Uint8Array.from([0xde, 0xad, 0xbe, 0xef]),
-                  },
-                ],
-              },
+              L: [
+                { N: '1' },
+                {
+                  B: Uint8Array.from([0xde, 0xad, 0xbe, 0xef]),
+                },
+              ],
             },
           },
           UpdateExpression: 'SET #attr0 = :val1',
@@ -4242,16 +4238,14 @@ describe('DataMapper', () => {
               },
               ExpressionAttributeValues: {
                 ':val2': {
-                  marshalled: {
-                    L: [
-                      { N: '1' },
-                      {
-                        B: Uint8Array.from([0xde, 0xad, 0xbe, 0xef]),
-                      },
-                    ],
-                  },
+                  L: [
+                    { N: '1' },
+                    {
+                      B: Uint8Array.from([0xde, 0xad, 0xbe, 0xef]),
+                    },
+                  ],
                 },
-                ':val3': 0,
+                ':val3': { N: '0' },
               },
               UpdateExpression: 'SET #attr1 = :val2, #attr0 = :val3',
             }
@@ -4278,18 +4272,16 @@ describe('DataMapper', () => {
                 '#attr2': 'buzz',
               },
               ExpressionAttributeValues: {
-                ':val1': 10,
+                ':val1': { N: '10' },
                 ':val3': {
-                  marshalled: {
-                    L: [
-                      { N: '1' },
-                      {
-                        B: Uint8Array.from([0xde, 0xad, 0xbe, 0xef]),
-                      },
-                    ],
-                  },
+                  L: [
+                    { N: '1' },
+                    {
+                      B: Uint8Array.from([0xde, 0xad, 0xbe, 0xef]),
+                    },
+                  ],
                 },
-                ':val4': 1,
+                ':val4': { N: '1' },
               },
               UpdateExpression: 'SET #attr2 = :val3, #attr0 = #attr0 + :val4',
             }
@@ -4349,18 +4341,15 @@ describe('DataMapper', () => {
                 '#attr2': 'baz',
               },
               ExpressionAttributeValues: {
-                ':val1': 600_000,
-                ':val3': 10,
+                ':val1': { N: '600000' },
+                ':val3': { N: '10' },
                 ':val4': {
-                  // Need to get rid of this
-                  marshalled: {
-                    L: [
-                      { N: '1' },
-                      {
-                        B: Uint8Array.from([0xde, 0xad, 0xbe, 0xef]),
-                      },
-                    ],
-                  },
+                  L: [
+                    { N: '1' },
+                    {
+                      B: Uint8Array.from([0xde, 0xad, 0xbe, 0xef]),
+                    },
+                  ],
                 },
               },
             }
@@ -4400,9 +4389,7 @@ describe('DataMapper', () => {
             '#attr0': 'buzz',
           },
           ExpressionAttributeValues: {
-            // TODO: is this shit intended?
-            ':val1': Uint8Array.from([0xde, 0xad, 0xbe, 0xef]),
-            // ":val1": { B: Uint8Array.from([0xde, 0xad, 0xbe, 0xef]) },
+            ':val1': { B: Uint8Array.from([0xde, 0xad, 0xbe, 0xef]) },
           },
           UpdateExpression: 'SET #attr0[1] = :val1',
         });

--- a/packages/dynamodb-data-mapper/src/DataMapper.ts
+++ b/packages/dynamodb-data-mapper/src/DataMapper.ts
@@ -25,6 +25,7 @@ import {
   waitUntilTableExists,
   waitUntilTableNotExists,
 } from '@aws-sdk/client-dynamodb';
+import { Marshaller } from '@driimus/dynamodb-auto-marshaller';
 import type { PerTableOptions, TableOptions, WriteRequest } from '@driimus/dynamodb-batch-iterator';
 import { BatchGet, BatchWrite } from '@driimus/dynamodb-batch-iterator';
 import type {
@@ -113,6 +114,7 @@ export class DataMapper {
   private readonly readConsistency: ReadConsistency;
   private readonly skipVersionCheck: boolean;
   private readonly tableNamePrefix: string;
+  private readonly marshaller = new Marshaller();
 
   constructor({
     client,
@@ -465,7 +467,13 @@ export class DataMapper {
       }
 
       if (Object.keys(attributes.values).length > 0) {
-        request.ExpressionAttributeValues = attributes.values;
+        request.ExpressionAttributeValues = {};
+        for (const key of Object.keys(attributes.values)) {
+          const val = attributes.values[key];
+          request.ExpressionAttributeValues[key] = AttributeValue.isAttributeValue(val)
+            ? val.marshalled
+            : (this.marshaller.marshallValue(val) as _AttributeValue);
+        }
       }
     }
 
@@ -717,7 +725,13 @@ export class DataMapper {
       }
 
       if (Object.keys(attributes.values).length > 0) {
-        request.ExpressionAttributeValues = attributes.values;
+        request.ExpressionAttributeValues = {};
+        for (const key of Object.keys(attributes.values)) {
+          const val = attributes.values[key];
+          request.ExpressionAttributeValues[key] = AttributeValue.isAttributeValue(val)
+            ? val.marshalled
+            : (this.marshaller.marshallValue(val) as _AttributeValue);
+        }
       }
     }
 
@@ -954,7 +968,13 @@ export class DataMapper {
     }
 
     if (Object.keys(attributes.values).length > 0) {
-      request.ExpressionAttributeValues = attributes.values;
+      request.ExpressionAttributeValues = {};
+      for (const key of Object.keys(attributes.values)) {
+        const val = attributes.values[key];
+        request.ExpressionAttributeValues[key] = AttributeValue.isAttributeValue(val)
+          ? val.marshalled
+          : (this.marshaller.marshallValue(val) as _AttributeValue);
+      }
     }
 
     const rawResponse = await this.client.send(new UpdateItemCommand(request));

--- a/packages/dynamodb-data-marshaller/src/marshallExpression.spec.ts
+++ b/packages/dynamodb-data-marshaller/src/marshallExpression.spec.ts
@@ -1,10 +1,4 @@
 import {
-  AttributePath,
-  FunctionExpression,
-  MathematicalExpression,
-  UpdateExpression,
-} from '@driimus/dynamodb-expressions';
-import {
   marshallConditionExpression,
   marshallFunctionExpression,
   marshallMathematicalExpression,
@@ -12,6 +6,12 @@ import {
   marshallUpdateExpression,
 } from './marshallExpression';
 import { Schema } from './SchemaType';
+import {
+  AttributePath,
+  FunctionExpression,
+  MathematicalExpression,
+  UpdateExpression,
+} from '@driimus/dynamodb-expressions';
 
 const schema: Schema = {
   foo: {
@@ -47,27 +47,22 @@ describe('marshallConditionExpression', () => {
     ).toEqual({
       expression: '#attr0 = :val1',
       ExpressionAttributeNames: { '#attr0': 'bar' },
-      ExpressionAttributeValues: { ':val1': 'baz' },
+      ExpressionAttributeValues: { ':val1': { S: 'baz' } },
     });
   });
 
   it('should map nested keys to their attributeName equivalents in bounding conditions', () => {
     expect(
       marshallConditionExpression(
-        {
-          type: 'Between',
-          subject: 'fizz',
-          lowerBound: 1,
-          upperBound: 5,
-        },
+        { type: 'Between', subject: 'fizz', lowerBound: 1, upperBound: 5 },
         schema
       )
     ).toEqual({
       expression: '#attr0 BETWEEN :val1 AND :val2',
       ExpressionAttributeNames: { '#attr0': 'buzz' },
       ExpressionAttributeValues: {
-        ':val1': 1,
-        ':val2': 5,
+        ':val1': { N: '1' },
+        ':val2': { N: '5' },
       },
     });
   });
@@ -75,20 +70,16 @@ describe('marshallConditionExpression', () => {
   it('should map nested keys to their attributeName equivalents in membership conditions', () => {
     expect(
       marshallConditionExpression(
-        {
-          type: 'Membership',
-          subject: 'foo',
-          values: ['bar', 'baz', 'quux'],
-        },
+        { type: 'Membership', subject: 'foo', values: ['bar', 'baz', 'quux'] },
         schema
       )
     ).toEqual({
       expression: '#attr0 IN (:val1, :val2, :val3)',
       ExpressionAttributeNames: { '#attr0': 'bar' },
       ExpressionAttributeValues: {
-        ':val1': 'bar',
-        ':val2': 'baz',
-        ':val3': 'quux',
+        ':val1': { S: 'bar' },
+        ':val2': { S: 'baz' },
+        ':val3': { S: 'quux' },
       },
     });
   });
@@ -96,20 +87,13 @@ describe('marshallConditionExpression', () => {
   it('should map nested keys to their attributeName equivalents in negated conditions', () => {
     expect(
       marshallConditionExpression(
-        {
-          type: 'Not',
-          condition: {
-            type: 'Equals',
-            subject: 'foo',
-            object: 'baz',
-          },
-        },
+        { type: 'Not', condition: { type: 'Equals', subject: 'foo', object: 'baz' } },
         schema
       )
     ).toEqual({
       expression: 'NOT (#attr0 = :val1)',
       ExpressionAttributeNames: { '#attr0': 'bar' },
-      ExpressionAttributeValues: { ':val1': 'baz' },
+      ExpressionAttributeValues: { ':val1': { S: 'baz' } },
     });
   });
 
@@ -120,12 +104,7 @@ describe('marshallConditionExpression', () => {
           type: 'And',
           conditions: [
             { type: 'Equals', subject: 'foo', object: 'baz' },
-            {
-              type: 'Between',
-              subject: 'fizz',
-              lowerBound: 1,
-              upperBound: 5,
-            },
+            { type: 'Between', subject: 'fizz', lowerBound: 1, upperBound: 5 },
           ],
         },
         schema
@@ -137,9 +116,9 @@ describe('marshallConditionExpression', () => {
         '#attr2': 'buzz',
       },
       ExpressionAttributeValues: {
-        ':val1': 'baz',
-        ':val3': 1,
-        ':val4': 5,
+        ':val1': { S: 'baz' },
+        ':val3': { N: '1' },
+        ':val4': { N: '5' },
       },
     });
   });
@@ -162,11 +141,7 @@ describe('marshallConditionExpression', () => {
 
     expect(
       marshallConditionExpression(
-        {
-          type: 'Function',
-          name: 'attribute_exists',
-          subject: 'nested.nested.scalar',
-        },
+        { type: 'Function', name: 'attribute_exists', subject: 'nested.nested.scalar' },
         schema
       )
     ).toEqual({
@@ -197,7 +172,7 @@ describe('marshallConditionExpression', () => {
         '#attr2': 'nested_scalar',
       },
       ExpressionAttributeValues: {
-        ':val3': 'substr',
+        ':val3': { S: 'substr' },
       },
     });
   });
@@ -235,7 +210,7 @@ describe('marshallFunctionExpression', () => {
         '#attr2': 'nested_scalar',
       },
       ExpressionAttributeValues: {
-        ':val3': 'foo',
+        ':val3': { S: 'foo' },
       },
     });
   });
@@ -251,7 +226,7 @@ describe('marshallMathematicalExpression', () => {
         '#attr0': 'buzz',
       },
       ExpressionAttributeValues: {
-        ':val1': 2,
+        ':val1': { N: '2' },
       },
     });
   });
@@ -291,8 +266,8 @@ describe('marshallUpdateExpression', () => {
         '#attr6': 'bar',
       },
       ExpressionAttributeValues: {
-        ':val5': 'boo',
-        ':val1': 1,
+        ':val5': { S: 'boo' },
+        ':val1': { N: '1' },
       },
     });
   });

--- a/packages/dynamodb-data-marshaller/src/marshallExpression.ts
+++ b/packages/dynamodb-data-marshaller/src/marshallExpression.ts
@@ -1,3 +1,4 @@
+import { Marshaller } from '@driimus/dynamodb-auto-marshaller';
 import type {
   ConditionExpression,
   ExpressionAttributeNameMap,
@@ -16,6 +17,8 @@ import {
 
 import type { Schema } from './SchemaType';
 import { toSchemaName } from './toSchemaName';
+
+const marshaller = new Marshaller();
 
 /**
  * A DynamoDB expression serialized to a string and accompanied by the name and
@@ -62,7 +65,7 @@ export function marshallConditionExpression(
   return {
     expression: serialized,
     ExpressionAttributeNames: attributes.names,
-    ExpressionAttributeValues: attributes.values,
+    ExpressionAttributeValues: marshaller.marshallItem(attributes.values),
   };
 }
 
@@ -85,7 +88,7 @@ export function marshallFunctionExpression(
   return {
     expression: serialized,
     ExpressionAttributeNames: attributes.names,
-    ExpressionAttributeValues: attributes.values,
+    ExpressionAttributeValues: marshaller.marshallItem(attributes.values),
   };
 }
 
@@ -108,7 +111,7 @@ export function marshallMathematicalExpression(
   return {
     expression: serialized,
     ExpressionAttributeNames: attributes.names,
-    ExpressionAttributeValues: attributes.values,
+    ExpressionAttributeValues: marshaller.marshallItem(attributes.values),
   };
 }
 
@@ -134,7 +137,7 @@ export function marshallProjectionExpression(
   return {
     expression: serialized,
     ExpressionAttributeNames: attributes.names,
-    ExpressionAttributeValues: attributes.values,
+    ExpressionAttributeValues: marshaller.marshallItem(attributes.values),
   };
 }
 
@@ -157,7 +160,7 @@ export function marshallUpdateExpression(
   return {
     expression: serialized,
     ExpressionAttributeNames: attributes.names,
-    ExpressionAttributeValues: attributes.values,
+    ExpressionAttributeValues: marshaller.marshallItem(attributes.values),
   };
 }
 

--- a/packages/dynamodb-expressions/package.json
+++ b/packages/dynamodb-expressions/package.json
@@ -43,7 +43,6 @@
     "@aws-sdk/client-dynamodb": "^3.113.0"
   },
   "dependencies": {
-    "@driimus/dynamodb-auto-marshaller": "workspace:*",
     "tslib": "^2.4.0"
   }
 }

--- a/packages/dynamodb-expressions/src/ExpressionAttributes.ts
+++ b/packages/dynamodb-expressions/src/ExpressionAttributes.ts
@@ -17,7 +17,6 @@ export type ExpressionAttributeValueMap = Record<string, AttributeValueModel>;
 export class ExpressionAttributes {
   readonly names: ExpressionAttributeNameMap = {};
   readonly values: ExpressionAttributeValueMap = {};
-  // Readonly marshaller = new Marshaller();
 
   private readonly nameMap: Record<string, string> = {};
   private _ctr = 0;
@@ -51,10 +50,6 @@ export class ExpressionAttributes {
    * @returns The substitution value to use in the expression.
    */
   addValue(value: any): string {
-    // Const modeledAttrValue = AttributeValue.isAttributeValue(value)
-    //         ? value.marshalled as AttributeValueModel
-    //         : this.marshaller.marshallValue(value) as AttributeValueModel;
-
     const substitution = `:val${this._ctr++}`;
     this.values[substitution] = value as AttributeValueModel;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,11 +135,9 @@ importers:
   packages/dynamodb-expressions:
     specifiers:
       '@aws-sdk/client-dynamodb': ^3.113.0
-      '@driimus/dynamodb-auto-marshaller': workspace:*
       tslib: ^2.4.0
       typescript: ^4.7.4
     dependencies:
-      '@driimus/dynamodb-auto-marshaller': link:../dynamodb-auto-marshaller
       tslib: 2.4.0
     devDependencies:
       '@aws-sdk/client-dynamodb': 3.118.0


### PR DESCRIPTION
Closes #1 by delegating marshalling responsibilities to the `dynamodb-data-marshaller` package.